### PR TITLE
Strong Semilattice ViewString update

### DIFF
--- a/doc/semicons.xml
+++ b/doc/semicons.xml
@@ -299,3 +299,174 @@ true]]></Example>
     </Description>
   </ManSection>
 <#/GAPDoc>
+
+<#GAPDoc Label="StrongSemilatticeOfSemigroups">
+  <ManSection>
+    <Func Name="StrongSemilatticeOfSemigroups" Arg="D, L, H"/>
+    <Returns>
+      A strong semilattice of semigroups.
+    </Returns>
+    <Description>
+      If <A>D</A> is a digraph, <A>L</A> is a list of semigroups, and <A>H</A>
+      is a list of lists of maps, then this function performs argument checks
+      and returns an <C>IsStrongSemilatticeOfSemigroups</C> object. The format
+      of the arguments is not required to be exactly analogous to Howie's
+      description above, but consistency amongst the arguments is required:
+      <List>
+        <Item>
+          <A>D</A> must be a digraph whose
+          <C>DigraphReflexiveTransitiveClosure</C> is a meet-semilattice. For
+          example, <C>Digraph([2, 3], [4], [4], []])</C> is valid and produces
+          a semilattice where the meet of <C>2</C> and <C>3</C> is <C>1</C>.
+        </Item>
+        <Item>
+          <A>L</A> must contain as many semigroups as there are vertices in
+          <A>D</A>.
+        </Item>
+        <Item>
+          <A>H</A> must be a list with as many elements as there are vertices
+          in <A>D</A>. Each element of <A>H</A> must itself be a (possibly
+          empty) list with as many entries as the corresponding vertex of
+          <A>D</A> has out-edges. The entries of each sublist must be the
+          corresponding homomorphisms: for example, if <A>D</A> is entered as
+          above, then <C>H[1][2]</C> must be the homomorphism <M>f_31</M>, i.e.
+          <C>H[1][2]</C> is an <C>IsMapping</C> object whose domain is a supset
+          of <C>L[3]</C> and whose range is a subset of <C>L[1]</C>.
+        </Item>
+      </List>
+      Note that in the example above, the edge <M>1 \rightarrow 4</M> is not
+      entered as part of the argument <A>D</A>, but it is still an edge in the
+      reflexive transitive closure of <A>D</A>. When greating the object, &GAP;
+      creates the homomorphism <M>f_{41}</M> by composing the mappings along
+      paths that lead from 4 to 1, and checks that composing along all possible
+      paths produces the same result.
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="IsStrongSemilatticeOfSemigroups">
+  <ManSection>
+    <Func Name="IsStrongSemilatticeOfSemigroups" Arg="obj"/>
+    <Returns>
+      <K>true</K> or <K>false</K>.
+    </Returns>
+    <Description>
+      Every SSS in &GAP; belongs to the category
+      <C>IsStrongSemilatticeOfSemigroups</C>. Basic operations in this category
+      allow the user to recover the three essential elements of an SSS object:
+      <Ref Attr="SemilatticeOfStrongSemilatticeOfSemigroups"/>,
+      <Ref Attr="SemigroupsOfStrongSemilatticeOfSemigroups"/>, and
+      <Ref Attr="HomomorphismsOfStrongSemilatticeOfSemigroups"/>.
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<!-- TODO link to digraphs refs -->
+
+<#GAPDoc Label="SemilatticeOfStrongSemilatticeOfSemigroups">
+  <ManSection>
+    <Func Name="SemilatticeOfStrongSemilatticeOfSemigroups" Arg="SSS"/>
+    <Returns>
+      A meet-semilattice digraph.
+    </Returns>
+    <Description>
+      If <A>SSS</A> is a strong semilattice of semigroups, this function
+      returns the underlying semilattice structure in the form of a Digraphs
+      object. Note that this may not be equal to the digraph passed as input
+      when the SSS was created: it is equal to reflexive transitive closure
+      of the input.
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="SemigroupsOfStrongSemilatticeOfSemigroups">
+  <ManSection>
+    <Func Name="SemigroupsOfStrongSemilatticeOfSemigroups" Arg="SSS"/>
+    <Returns>
+      A list of semigroups.
+    </Returns>
+    <Description>
+      If <A>SSS</A> is a strong semilattice of semigroups, this function
+      returns the list of semigroups that make up <A>SSS</A>. The position of
+      a semigroup in the list corresponds to the node of the semilattice where
+      that semigroup lies.
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="HomomorphismsOfStrongSemilatticeOfSemigroups">
+  <ManSection>
+    <Func Name="HomomorphismsOfStrongSemilatticeOfSemigroups" Arg="SSS"/>
+    <Returns>
+      A list of lists of mappings.
+    </Returns>
+    <Description>
+      If <A>SSS</A> is a strong semilattice of <M>n</M> semigroups, this
+      function returns an <M>n \times n</M> list where the <M>(i, j)</M>th
+      entry of the list is the homomorphism <M>f_{ji}</M>, provided
+      <M>i \leq j</M> in the semilattice. If this last condition is not true,
+      then the entry is <K>fail</K>.
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="IsSSSE">
+  <ManSection>
+    <Func Name="IsSSSE" Arg="obj"/>
+    <Returns>
+      <K>true</K> or <K>false</K>.
+    </Returns>
+    <Description>
+      All elements of an SSS belong in the category <C>IsSSSE</C> (for "Strong
+      Semilattice of Semigroups Element").
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="SSSE">
+  <ManSection>
+    <Func Name="SSSE" Arg="SSS, n, x"/>
+    <Returns>
+      The element of the strong semilattice of semigroups <A>SSS</A> which lies
+      in semigroup number <A>n</A> and which corresponds to the element
+      <A>x</A>.
+    </Returns>
+    <Description>
+      If <A>n</A> is a positive integer no greater than the number of vertices
+      in the underlying semilattice of <A>SSS</A>, and if <A>x</A> is an
+      element of the <A>n</A>th semigroup of <A>SSS</A>, then this function
+      returns an <Ref Attr="IsSSSE"/> object which is an element of <A>SSS</A>.
+      SSSEs of the same SSS can be compared and multiplied.
+      <P/>
+
+      If <C>el</C> is an SSSE, then the underlying strong semilattice of
+      semigroups object it belongs to can be recovered by calling
+      <C>StrongSemilatticeOfSemigroups(el)</C>.
+      <Example><![CDATA[
+gap> D := Digraph([[2, 3], [4], [4], []]);;
+gap> S4 := FullTransformationMonoid(2);;
+gap> S3 := FullTransformationMonoid(3);;
+gap> pairs := [[Transformation([1, 2]), Transformation([2, 1])]];;
+gap> cong := SemigroupCongruence(S4, pairs);;
+gap> S2 := S4 / cong;;
+gap> S1 := TrivialSemigroup();;
+gap> L := [S1, S2, S3, S4];;
+gap> idfn := function(t) return IdentityTransformation; end;;
+gap> f21 := MappingByFunction(S2, S1, idfn);;
+gap> f31 := MappingByFunction(S3, S1, idfn);;
+gap> f42 := HomomorphismQuotientSemigroup(cong);;
+gap> f43 := IdentityMapping(S4);;
+gap> H := [[f21, f31], [f42], [f43], []];;
+gap> SSS := StrongSemilatticeOfSemigroups(D, L, H);
+<strong semilattice of 4 semigroups>
+gap> Size(SSS);
+34
+gap> x := SSSE(SSS, 3, Elements(S3)[10]);
+SSSE(3, Transformation( [ 2, 1, 1 ] ))
+gap> y := SSSE(SSS, 4, Elements(S4)[1]);
+SSSE(4, Transformation( [ 1, 1 ] ))
+gap> x * y;
+SSSE(3, Transformation( [ 1, 1, 1 ] ))]]></Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>

--- a/doc/z-chap09.xml
+++ b/doc/z-chap09.xml
@@ -32,4 +32,40 @@
   <!--**********************************************************************-->
   <!--**********************************************************************-->
 
+  <Section Label = "Strong semilattices of semigroups">
+    <Heading>
+      Strong semilattices of semigroups
+    </Heading>
+
+    In this section, we describe how &Semigroups; can be used to create and
+    manipulate strong semilattices of semigroups (SSSs).
+    Strong semilattices of semigroups are described, for example, in Section
+    4.1 of <Cite Key = "Howie1995aa"/>.
+    They consist of a meet-semilattice <M>Y</M> along with a collection of
+    semigroups <M>S_a</M> for each <M>a</M> in <M>Y</M>, and a collection of
+    homomorphisms <M>f_{ab} : S_a \rightarrow S_b</M> for each <M>a</M> and
+    <M>b</M> in <M>Y</M> such that <M>a \geq b</M>.
+    <P/>
+
+    The product of two elements <M>x \in S_a, y \in S_b</M> is defined to lie
+    in the semigroup <M>S_c</M>, corresponding to the meet <M>c</M> of
+    <M>a, b \in Y</M>. The exact element of <M>S_c</M> equal to the product
+    is obtained using the homomorphisms of the SSS:
+    <P/>
+
+    <!-- TODO formatting -->
+    <M>xy = (x f_{ac})(y f_{bc}).</M>
+
+    <#Include Label = "StrongSemilatticeOfSemigroups">
+    <#Include Label = "SSSE">
+    <#Include Label = "IsSSSE">
+    <#Include Label = "IsStrongSemilatticeOfSemigroups">
+    <#Include Label = "SemilatticeOfStrongSemilatticeOfSemigroups">
+    <#Include Label = "SemigroupsOfStrongSemilatticeOfSemigroups">
+    <#Include Label = "HomomorphismsOfStrongSemilatticeOfSemigroups">
+  </Section>
+
+  <!--**********************************************************************-->
+  <!--**********************************************************************-->
+
 </Chapter>

--- a/gap/main/fropin.gi
+++ b/gap/main/fropin.gi
@@ -60,6 +60,9 @@ InstallTrueMethod(IsGeneratorsOfEnumerableSemigroup,
 InstallTrueMethod(IsGeneratorsOfEnumerableSemigroup,
                   IsMcAlisterTripleSemigroupElementCollection);
 
+InstallTrueMethod(IsGeneratorsOfEnumerableSemigroup,
+                  IsSSSECollection);
+
 InstallMethod(IsGeneratorsOfEnumerableSemigroup,
 "for a matrix over semiring collection", [IsMatrixOverSemiringCollection],
 IsGeneratorsOfSemigroup);

--- a/gap/semigroups/semicons.gd
+++ b/gap/semigroups/semicons.gd
@@ -21,8 +21,6 @@ DeclareGlobalFunction("RightZeroSemigroup");
 DeclareConstructor("BrandtSemigroupCons", [IsSemigroup, IsGroup, IsPosInt]);
 DeclareGlobalFunction("BrandtSemigroup");
 
-DeclareOperation("StrongSemilatticeOfSemigroups", [IsDigraph, IsList, IsList]);
-
 DeclareCategory("IsSSSE", IsAssociativeElement);
 DeclareCategoryCollections("IsSSSE");
 
@@ -31,6 +29,9 @@ DeclareCategoryCollections("IsSSSE");
 # 2) the node of the digraph;
 # 3) the underlying semigroup element itself.
 DeclareRepresentation("IsSSSERep", IsSSSE and IsPositionalObjectRep, 2);
+
+DeclareOperation("StrongSemilatticeOfSemigroups", [IsDigraph, IsList, IsList]);
+DeclareOperation("StrongSemilatticeOfSemigroups", [IsSSSERep]);
 
 DeclareCategory("IsStrongSemilatticeOfSemigroups",
                 IsSemigroup and IsSSSECollection);

--- a/gap/semigroups/semicons.gd
+++ b/gap/semigroups/semicons.gd
@@ -26,7 +26,7 @@ DeclareOperation("StrongSemilatticeOfSemigroups", [IsDigraph, IsList, IsList]);
 DeclareCategory("IsSSSE", IsAssociativeElement);
 DeclareCategoryCollections("IsSSSE");
 
-# Objects in IsSSERep have 2 slots:
+# Objects in IsSSERep have 3 slots:
 # 1) the strong semilattice of semigroup of which this is an element;
 # 2) the node of the digraph;
 # 3) the underlying semigroup element itself.
@@ -47,4 +47,3 @@ DeclareOperation("SSSE",
                  [IsStrongSemilatticeOfSemigroups,
                   IsPosInt,
                   IsAssociativeElement]);
-# DeclareAttribute("StrongSemilatticeOfSemigroups", IsSSSERep);

--- a/gap/semigroups/semicons.gi
+++ b/gap/semigroups/semicons.gi
@@ -855,8 +855,6 @@ function(D, semigroups, homomorphisms)
     od;
   od;
   # TODO add: check commutativity;
-  # check domains and ranges of homs make sense; (done)
-  # check all homs are actally homomorphisms. (done)
   # otherwise errors will only show up when trying to actually multiply things.
 
   # I think this works for now as argument checking: we can update this when we
@@ -919,11 +917,11 @@ function(D, semigroups, homomorphisms)
   return out;
 end);
 
-# InstallMethod(Size, "for a strong semilattice of semigroups",
-# [IsStrongSemilatticeOfSemigroups],
-# function(S)
-#   return Sum(SemigroupsOfStrongSemilatticeOfSemigroups(S), Size);
-# end);
+InstallMethod(Size, "for a strong semilattice of semigroups",
+[IsStrongSemilatticeOfSemigroups],
+function(S)
+  return Sum(SemigroupsOfStrongSemilatticeOfSemigroups(S), Size);
+end);
 
 InstallMethod(ViewString, "for a strong semilattice of semigroups",
 [IsStrongSemilatticeOfSemigroups],
@@ -948,7 +946,6 @@ function(S, n, x)
   return Objectify(ElementTypeOfStrongSemilatticeOfSemigroups(S), [S, n, x]);
 end);
 
-# TODO implement \=, \< for IsSSSREP
 InstallMethod(\=, "for SSSEs", IsIdenticalObj,
 [IsSSSERep, IsSSSERep],
 function(x, y)

--- a/gap/semigroups/semicons.gi
+++ b/gap/semigroups/semicons.gi
@@ -819,12 +819,13 @@ function(D, semigroups, homomorphisms)
   if not IsMeetSemilatticeDigraph(DigraphReflexiveTransitiveClosure(D)) then
     ErrorNoReturn("expected a digraph whose reflexive transitive closure ",
                   "is a meet semilattice digraph as first argument");
-    for s in semigroups do
-      if not IsSemigroup(s) then
-        ErrorNoReturn("expected a list of semigroups as second argument");
-      fi;
-    od;
-  elif DigraphNrVertices(D) <> Length(semigroups) then
+  fi;
+  for s in semigroups do
+    if not IsSemigroup(s) then
+      ErrorNoReturn("expected a list of semigroups as second argument");
+    fi;
+  od;
+  if DigraphNrVertices(D) <> Length(semigroups) then
     ErrorNoReturn("the number of vertices of the first argumement D must ",
                   "be equal to the length of the second argument semigroups");
   elif DigraphNrVertices(D) <> Length(homomorphisms) then
@@ -843,7 +844,8 @@ function(D, semigroups, homomorphisms)
     for j in [1 .. Length(homomorphisms[i])] do
       if not RespectsMultiplication(homomorphisms[i][j]) then
         ErrorNoReturn("expected a list of lists of homomorphisms ",
-                      "as third argument");
+                      "as third argument. homomorphisms[", i,
+                      "][", j, "] is not a homomorphism");
       fi;
       if  (not IsSubset(Source(homomorphisms[i][j]),
                         semigroups[OutNeighbours(D)[i][j]])) or
@@ -965,9 +967,9 @@ InstallMethod(SSSE,
 [IsStrongSemilatticeOfSemigroups, IsPosInt, IsAssociativeElement],
 function(S, n, x)
   if n > Size(SemigroupsOfStrongSemilatticeOfSemigroups(S)) then
-    ErrorNoReturn("where S and n are the 1st and 2nd arguments respectively, ",
-                  "expected n to be an integer between 1 and ",
-                  "Size(SemigroupsOfStrongSemilatticeOfSemigroups(S))");
+    ErrorNoReturn("expected second argument to be an integer between 1 and ",
+                  "the size of the semilattice, i.e. ",
+                  Size(SemigroupsOfStrongSemilatticeOfSemigroups(S)));
   elif not x in SemigroupsOfStrongSemilatticeOfSemigroups(S)[n] then
     ErrorNoReturn("where S, n and x are the 1st, 2nd and 3rd arguments ",
                   "respectively, expected x to be an element of ",
@@ -1011,14 +1013,16 @@ function(x)
   return x![1];
 end);
 
-InstallMethod(ChooseHashFunction, "for SSSE and int",
-[IsSSSERep, IsInt],
-function(x, data)
-  local hashes, hashfunc;
-  hashes := List(SemigroupsOfStrongSemilatticeOfSemigroups(x![1]),
-                 y -> ChooseHashFunction(Representative(y), data));
-  hashfunc := function(y, d)
-    return 17 * y![2] + hashes[y![2]].func(y![3], d);
-  end;
-  return rec(func := hashfunc, data := data);
-end);
+# TODO hash function currently unused
+
+# InstallMethod(ChooseHashFunction, "for SSSE and int",
+# [IsSSSERep, IsInt],
+# function(x, data)
+#   local hashes, hashfunc;
+#   hashes := List(SemigroupsOfStrongSemilatticeOfSemigroups(x![1]),
+#                  y -> ChooseHashFunction(Representative(y), data));
+#   hashfunc := function(y, d)
+#     return 17 * y![2] + hashes[y![2]].func(y![3], d);
+#   end;
+#   return rec(func := hashfunc, data := data);
+# end);

--- a/gap/semigroups/semicons.gi
+++ b/gap/semigroups/semicons.gi
@@ -813,6 +813,9 @@ function(D, semigroups, homomorphisms)
   local efam, etype, type, maps, n, rtclosure, path, len, tobecomposed, gens,
   out, s, i, j, paths, firsthom;
 
+  #  TODO would it be advisable to ensure all the semigroups are distinct?
+  #  In the GAP sense of distinct, that is
+
   if not IsMeetSemilatticeDigraph(DigraphReflexiveTransitiveClosure(D)) then
     ErrorNoReturn("expected a digraph whose reflexive transitive closure ",
                   "is a meet semilattice digraph as first argument");
@@ -1002,11 +1005,11 @@ function(x)
   return Concatenation("SSSE(", ViewString(x![2]), ", ", ViewString(x![3]), ")");
 end);
 
-# InstallMethod(StrongSemilatticeOfSemigroups, "for a SSSE rep",
-# [IsSSSERep],
-# function(x)
-#   return x![1];
-# end);
+InstallMethod(StrongSemilatticeOfSemigroups, "for a SSSE rep",
+[IsSSSERep],
+function(x)
+  return x![1];
+end);
 
 InstallMethod(ChooseHashFunction, "for SSSE and int",
 [IsSSSERep, IsInt],

--- a/gap/semigroups/semicons.gi
+++ b/gap/semigroups/semicons.gi
@@ -887,6 +887,7 @@ function(D, semigroups, homomorphisms)
         # efficient here.
         # for some larger digraphs, the current method might compute some
         # compositions of homomorphisms several times.
+        # This should be a FIXME.
       else
         Add(maps[i], fail);
         # is fail a reasonable thing to add here?
@@ -964,12 +965,6 @@ function(x, y)
   D    := SemilatticeOfStrongSemilatticeOfSemigroups(x![1]);
   meet := PartialOrderDigraphMeetOfVertices(D, x![2], y![2]);
   maps := HomomorphismsOfStrongSemilatticeOfSemigroups(x![1]);
-  # TODO should compose functions if necessary!
-  #      no longer necessary since we'll take the "refl. trans. closure"
-  #      of the homomorphisms and store in a  matrix.
-  # TODO check if x and y belong to the same semigroup, or if x < y.
-  #      this is no longer necessary since we will ensure we fill in the
-  #      maps matrix with the identity down the diagonal.
   return SSSE(x![1],
               meet,
               (x![3] ^ (maps[meet][x![2]])) * (y![3] ^ (maps[meet][y![2]])));

--- a/gap/semigroups/semicons.gi
+++ b/gap/semigroups/semicons.gi
@@ -836,15 +836,26 @@ function(D, semigroups, homomorphisms)
                     "respectively, the length of homomorphisms[i] must be ",
                     "equal to OutNeighbours(D)[i]");
     fi;
-    for s in homomorphisms[i] do
-      if Length(homomorphisms[i]) > 0 and not RespectsMultiplication(s) then
+    for j in [1 .. Length(homomorphisms[i])] do
+      if not RespectsMultiplication(homomorphisms[i][j]) then
         ErrorNoReturn("expected a list of lists of homomorphisms ",
                       "as third argument");
       fi;
+      if  (not IsSubset(Source(homomorphisms[i][j]),
+                        semigroups[OutNeighbours(D)[i][j]])) or
+          (not IsSubset(semigroups[i],
+                        Range(homomorphisms[i][j]))) then
+        ErrorNoReturn("expected homomorphism from ",
+                      OutNeighbours(D)[i][j],
+                      " to ",
+                      i,
+                      " to have correct source and range");
+      fi;
     od;
   od;
-  # TODO add: check commutativity; check domains and ranges of homs make sense;
-  # check all homs are actally homomorphisms.
+  # TODO add: check commutativity;
+  # check domains and ranges of homs make sense; (done)
+  # check all homs are actally homomorphisms. (done)
   # otherwise errors will only show up when trying to actually multiply things.
 
   # I think this works for now as argument checking: we can update this when we

--- a/gap/semigroups/semicons.gi
+++ b/gap/semigroups/semicons.gi
@@ -837,11 +837,16 @@ function(D, semigroups, homomorphisms)
                     "equal to OutNeighbours(D)[i]");
     fi;
     for s in homomorphisms[i] do
-      if Length(homomorphisms[i]) > 0 and not IsMapping(s) then
-        ErrorNoReturn("expected a list of lists of mappings as third argument");
+      if Length(homomorphisms[i]) > 0 and not RespectsMultiplication(s) then
+        ErrorNoReturn("expected a list of lists of homomorphisms ",
+                      "as third argument");
       fi;
     od;
   od;
+  # TODO add: check commutativity; check domains and ranges of homs make sense;
+  # check all homs are actally homomorphisms.
+  # otherwise errors will only show up when trying to actually multiply things.
+
   # I think this works for now as argument checking: we can update this when we
   # figure out more specifics of what we want the arguments to be
   efam := NewFamily("StrongSemilatticeOfSemigroupsElementsFamily", IsSSSE);

--- a/gap/semigroups/semicons.gi
+++ b/gap/semigroups/semicons.gi
@@ -872,6 +872,16 @@ function(D, semigroups, homomorphisms)
     Add(maps, []);
     for j in [1 .. n] do
       if i = j then
+        # First check that if a homomorphism from i to i was defined, it
+        # is the identity
+        if IsDigraphEdge(D, [i, i]) then
+          if homomorphisms[i][Position(OutNeighboursOfVertex(D, i), i)]
+              <> IdentityMapping(semigroups[i]) then
+             ErrorNoReturn("Expected homomorphism from ",
+                           i, " to ", i,
+                           " to be the identity");
+           fi;
+        fi;
         Add(maps[i], IdentityMapping(semigroups[i]));
       elif IsDigraphEdge(rtclosure, [i, j]) then
         paths        := IteratorOfPaths(D, i, j);

--- a/gap/semigroups/semicons.gi
+++ b/gap/semigroups/semicons.gi
@@ -810,8 +810,9 @@ InstallMethod(StrongSemilatticeOfSemigroups,
 "for a digraph, a list, and a list",
 [IsDigraph, IsList, IsList],
 function(D, semigroups, homomorphisms)
-  local efam, etype, type, out, s, i, j,
-        maps, n, rtclosure, path, len, tobecomposed;
+  local efam, etype, type, maps, n, rtclosure, path, len, tobecomposed, gens,
+  out, s, i, j;
+
   if not IsMeetSemilatticeDigraph(DigraphReflexiveTransitiveClosure(D)) then
     ErrorNoReturn("expected a digraph whose reflexive transitive closure ",
                   "is a meet semilattice digraph as first argument");
@@ -866,8 +867,7 @@ function(D, semigroups, homomorphisms)
   type := NewType(CollectionsFamily(efam),
                   IsStrongSemilatticeOfSemigroups
                     and IsComponentObjectRep
-                    and IsAttributeStoringRep
-                    and IsEnumerableSemigroupRep);
+                    and IsAttributeStoringRep);
 
   # the next section converts the list of homomorphisms into a matrix,
   # composing when necessary.
@@ -897,6 +897,13 @@ function(D, semigroups, homomorphisms)
   od;
 
   out := rec();
+
+  gens := [];
+  for i in [1 .. Length(semigroups)] do
+    Append(gens, List(GeneratorsOfSemigroup(semigroups[i]),
+                      x -> Objectify(etype, [out, i, x])));
+  od;
+
   ObjectifyWithAttributes(out,
                           type,
                           SemilatticeOfStrongSemilatticeOfSemigroups,
@@ -906,27 +913,17 @@ function(D, semigroups, homomorphisms)
                           HomomorphismsOfStrongSemilatticeOfSemigroups,
                           maps,
                           ElementTypeOfStrongSemilatticeOfSemigroups,
-                          etype);
+                          etype,
+                          GeneratorsOfMagma,
+                          gens);
   return out;
 end);
 
-InstallMethod(GeneratorsOfMagma, "for a strong semilattice of semigroups",
-[IsStrongSemilatticeOfSemigroups],
-function(S)
-  local T, gens, i;
-  T := SemigroupsOfStrongSemilatticeOfSemigroups(S);
-  gens := [];
-  for i in [1 .. Length(T)] do
-    Append(gens, List(GeneratorsOfSemigroup(T[i]), x -> SSSE(S, i, x)));
-  od;
-  return gens;
-end);
-
-InstallMethod(Size, "for a strong semilattice of semigroups",
-[IsStrongSemilatticeOfSemigroups],
-function(S)
-  return Sum(SemigroupsOfStrongSemilatticeOfSemigroups(S), Size);
-end);
+# InstallMethod(Size, "for a strong semilattice of semigroups",
+# [IsStrongSemilatticeOfSemigroups],
+# function(S)
+#   return Sum(SemigroupsOfStrongSemilatticeOfSemigroups(S), Size);
+# end);
 
 InstallMethod(ViewString, "for a strong semilattice of semigroups",
 [IsStrongSemilatticeOfSemigroups],

--- a/gap/semigroups/semicons.gi
+++ b/gap/semigroups/semicons.gi
@@ -854,25 +854,27 @@ function(D, semigroups, homomorphisms)
 
   # the next section converts the list of homomorphisms into a matrix,
   # composing when necessary.
-  maps := [ ];
+  maps := [];
   n := Length(semigroups);
   rtclosure := DigraphReflexiveTransitiveClosure(D);
   for i in [1 .. n] do
     Add(maps, []);
     for j in [1 .. n] do
       if i = j then
-	Add(maps[i], IdentityMapping(semigroups[i]));
+        Add(maps[i], IdentityMapping(semigroups[i]));
       elif IsDigraphEdge(rtclosure, [i, j]) then
-	path := DigraphPath(D, i, j);
-	len  := Length(path[2]);
-	tobecomposed := List([1 .. len], x -> homomorphisms[path[1][x]][path[2][x]]);
-	Add(maps[i], CompositionMapping(tobecomposed));
-	# NB. perhaps a dynamic programming approach would be more efficient here.
-	# for some larger digraphs, the current method might compute some compositions
-	# of homomorphisms several times.
+        path := DigraphPath(D, i, j);
+        len  := Length(path[2]);
+        tobecomposed := List([1 .. len],
+                              x -> homomorphisms[path[1][x]][path[2][x]]);
+        Add(maps[i], CompositionMapping(tobecomposed));
+        # NB. perhaps a dynamic programming approach would be more
+        # efficient here.
+        # for some larger digraphs, the current method might compute some
+        # compositions of homomorphisms several times.
       else
-	Add(maps[i], fail);
-	# is fail a reasonable thing to add here?
+        Add(maps[i], fail);
+        # is fail a reasonable thing to add here?
       fi;
     od;
   od;

--- a/gap/semigroups/semicons.gi
+++ b/gap/semigroups/semicons.gi
@@ -958,8 +958,11 @@ end);
 InstallMethod(ViewString, "for a strong semilattice of semigroups",
 [IsStrongSemilatticeOfSemigroups],
 function(S)
-  return StringFormatted("<strong semilattice of {} semigroups>",
-                         Size(SemigroupsOfStrongSemilatticeOfSemigroups(S)));
+  local size;
+  size := Size(SemigroupsOfStrongSemilatticeOfSemigroups(S));
+  return Concatenation("<strong semilattice of ",
+                       String(size),
+                       " semigroups>");
 end);
 
 InstallMethod(SSSE,

--- a/gap/semigroups/semicons.gi
+++ b/gap/semigroups/semicons.gi
@@ -850,7 +850,8 @@ function(D, semigroups, homomorphisms)
   type := NewType(CollectionsFamily(efam),
                   IsStrongSemilatticeOfSemigroups
                     and IsComponentObjectRep
-                    and IsAttributeStoringRep);
+                    and IsAttributeStoringRep
+                    and IsEnumerableSemigroupRep);
 
   # the next section converts the list of homomorphisms into a matrix,
   # composing when necessary.
@@ -941,14 +942,9 @@ function(x, y)
   return x![1] = y![1] and x![2] = y![2] and x![3] = y![3];
 end);
 
-InstallMethod(\<, "for SSSEs", IsIdenticalObj,
-[IsSSSERep, IsSSSERep],
+InstallMethod(\<, "for SSSEs", IsIdenticalObj, [IsSSSERep, IsSSSERep],
 function(x, y)
-  local D;
-  D := SemilatticeOfStrongSemilatticeOfSemigroups(x![1]);
-  return x![1] = y![1]
-         and ((x![2] <> y![2] and IsDigraphEdge(D, x![2], y![2]))
-              or (x![2] = y![2] and x![3] < y![3]));
+  return (x![2] < y![2]) or (x![2] = y![2] and x![3] < y![3]);
 end);
 
 InstallMethod(\*, "for SSSEs", IsIdenticalObj,
@@ -980,3 +976,15 @@ end);
 # function(x)
 #   return x![1];
 # end);
+
+InstallMethod(ChooseHashFunction, "for SSSE and int",
+[IsSSSERep, IsInt],
+function(x, data)
+  local hashes, hashfunc;
+  hashes := List(SemigroupsOfStrongSemilatticeOfSemigroups(x![1]),
+                 y -> ChooseHashFunction(Representative(y), data));
+  hashfunc := function(y, d)
+    return 17 * y![2] + hashes[y![2]].func(y![3], d);
+  end;
+  return rec(func := hashfunc, data := data);
+end);

--- a/tst/standard/semicons.tst
+++ b/tst/standard/semicons.tst
@@ -1150,6 +1150,16 @@ fail
 
 #
 gap> Unbind(S);
+# Unbind strong semilattice vars
+# TODO use less global variables
+gap> Unbind(D, L, H, SSS);
+gap> Unbind(tr, id, sm, cf, mp, sl);
+gap> Unbind(c1, c2, m1, m2);
+gap> Unbind(x, y, z);
+gap> Unbind(S1, S2, S3, S4, S5);
+gap> Unbind(map53f, map53, map31f, map31, map52f, map52, map21f, map21, map43);
+gap> Unbind(cong31, cong311, cong312, cong313);
+
 
 # 
 gap> SEMIGROUPS.StopTest();

--- a/tst/standard/semicons.tst
+++ b/tst/standard/semicons.tst
@@ -1150,16 +1150,44 @@ fail
 
 #
 gap> Unbind(S);
+
 # Unbind strong semilattice vars
 # TODO use less global variables
-gap> Unbind(D, L, H, SSS);
-gap> Unbind(tr, id, sm, cf, mp, sl);
-gap> Unbind(c1, c2, m1, m2);
-gap> Unbind(x, y, z);
-gap> Unbind(S1, S2, S3, S4, S5);
-gap> Unbind(map53f, map53, map31f, map31, map52f, map52, map21f, map21, map43);
-gap> Unbind(cong31, cong311, cong312, cong313);
-
+gap> Unbind(D);
+gap> Unbind(L);
+gap> Unbind(H);
+gap> Unbind(SSS);
+gap> Unbind(tr);
+gap> Unbind(id);
+gap> Unbind(sm);
+gap> Unbind(cf);
+gap> Unbind(mp);
+gap> Unbind(sl);
+gap> Unbind(c1);
+gap> Unbind(c2);
+gap> Unbind(m1);
+gap> Unbind(m2);
+gap> Unbind(x);
+gap> Unbind(y);
+gap> Unbind(z);
+gap> Unbind(S1);
+gap> Unbind(S2);
+gap> Unbind(S3);
+gap> Unbind(S4);
+gap> Unbind(S5);
+gap> Unbind(map53f);
+gap> Unbind(map53);
+gap> Unbind(map31f);
+gap> Unbind(map31);
+gap> Unbind(map52f);
+gap> Unbind(map52);
+gap> Unbind(map21f);
+gap> Unbind(map21);
+gap> Unbind(map43);
+gap> Unbind(cong31);
+gap> Unbind(cong311);
+gap> Unbind(cong312);
+gap> Unbind(cong313);
 
 # 
 gap> SEMIGROUPS.StopTest();

--- a/tst/standard/semicons.tst
+++ b/tst/standard/semicons.tst
@@ -949,6 +949,205 @@ gap> S := BrandtSemigroup(IsIntegerMatrixSemigroup, DihedralGroup(4), 3);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `BrandtSemigroupCons' on 3 arguments
 
+# constructions: strong semilattices of semigroups: trivial argument checks
+gap> D := CompleteDigraph(2);;
+gap> tr := TrivialSemigroup();;
+gap> id := IdentityMapping(tr);;
+gap> StrongSemilatticeOfSemigroups(D, [tr, tr], [[id, id], [id, id]]);
+Error, expected a digraph whose reflexive transitive closure is a meet semilat\
+tice digraph as first argument
+gap> D := Digraph([[2], []]);;
+gap> StrongSemilatticeOfSemigroups(D, [tr, 1], [[id], []]);
+Error, expected a list of semigroups as second argument
+gap> StrongSemilatticeOfSemigroups(D, [tr, tr, tr], [[id], []]);
+Error, the number of vertices of the first argumement D must be equal to the l\
+ength of the second argument semigroups
+gap> StrongSemilatticeOfSemigroups(D, [tr, tr], [[id], [], []]);
+Error, where D is the first argument, expected a list of length DigraphNrVerti\
+ces(D) as third argument
+gap> StrongSemilatticeOfSemigroups(D, [tr, tr], [1, []]);
+Error, expected a list of lists as third argument
+gap> StrongSemilatticeOfSemigroups(D, [tr, tr], [[id, id], []]);
+Error, where D and homomorphisms are the 1st and 3rd arguments respectively, t\
+he length of homomorphisms[i] must be equal to OutNeighbours(D)[i]
+gap> sm := FullTransformationMonoid(2);;
+gap> cf := function(x) return Transformation([2, 1]); end;;
+gap> mp := MappingByFunction(sm, sm, cf);;
+gap> StrongSemilatticeOfSemigroups(D, [sm, sm], [[mp], []]);
+Error, expected a list of lists of homomorphisms as third argument. homomorphi\
+sms[1][1] is not a homomorphism
+gap> StrongSemilatticeOfSemigroups(D, [tr, sm], [[id], []]);
+Error, expected homomorphism from 2 to 1 to have correct source and range
+gap> StrongSemilatticeOfSemigroups(D, [sm, tr], [[id], []]);
+<strong semilattice of 2 semigroups>
+gap> id := IdentityMapping(sm);;
+gap> StrongSemilatticeOfSemigroups(D, [sm, tr], [[id], []]);
+<strong semilattice of 2 semigroups>
+
+# constructions: strong semilattices of semigroups: homomorphism checks
+gap> D := Digraph([[2, 3], [4], [4], []]);;
+gap> sm := FullTransformationMonoid(2);;
+gap> id := IdentityMapping(sm);;
+gap> c1 := function(x) return Transformation([1, 1]); end;;
+gap> c2 := function(x) return Transformation([2, 2]); end;;
+gap> m1 := MappingByFunction(sm, sm, c1);;
+gap> m2 := MappingByFunction(sm, sm, c2);;
+gap> L := [sm, sm, sm, sm];;
+gap> H := [[m1, m2], [id], [id], []];;
+gap> StrongSemilatticeOfSemigroups(D, L, H);
+Error, Composing homomorphisms along different paths from 1 to 
+4 does not produce the same result. The homomorphisms must commute
+gap> D := Digraph([[2, 3], [4], [4], [4]]);;
+gap> H := [[id, id], [id], [id], [m1]];;
+gap> StrongSemilatticeOfSemigroups(D, L, H);
+Error, Expected homomorphism from 4 to 4 to be the identity
+
+# constructions: strong semilattices of semigroups: valid example
+gap> D := Digraph([[2, 3], [2], []]);;
+gap> sm := FullTransformationMonoid(2);;
+gap> id := IdentityMapping(sm);;
+gap> c1 := function(x) return Transformation([1, 1]); end;;
+gap> c2 := function(x) return Transformation([2, 2]); end;;
+gap> m1 := MappingByFunction(sm, sm, c1);;
+gap> m2 := MappingByFunction(sm, sm, c2);;
+gap> L := [sm, sm, sm];;
+gap> H := [[m1, m2], [id], []];;
+gap> SSS := StrongSemilatticeOfSemigroups(D, L, H);
+<strong semilattice of 3 semigroups>
+gap> Size(SSS);
+12
+
+# constructions: strong semilattices of semigroups: SSSEs
+gap> D := Digraph([[2, 3], [2], []]);;
+gap> sm := FullTransformationMonoid(2);;
+gap> id := IdentityMapping(sm);;
+gap> c1 := function(x) return Transformation([1, 1]); end;;
+gap> c2 := function(x) return Transformation([2, 2]); end;;
+gap> m1 := MappingByFunction(sm, sm, c1);;
+gap> m2 := MappingByFunction(sm, sm, c2);;
+gap> L := [sm, sm, sm];;
+gap> H := [[m1, m2], [id], []];;
+gap> SSS := StrongSemilatticeOfSemigroups(D, L, H);;
+gap> SSSE(SSS, 10, IdentityTransformation);
+Error, expected second argument to be an integer between 1 and the size of the\
+ semilattice, i.e. 3
+gap> SSSE(SSS, 1, Transformation([3, 2, 1]));
+Error, where S, n and x are the 1st, 2nd and 3rd arguments respectively, expec\
+ted x to be an element of SemigroupsOfStrongSemilatticeOfSemigroups(S)[n]
+gap> x := SSSE(SSS, 2, Transformation([2, 1]));
+SSSE(2, Transformation( [ 2, 1 ] ))
+gap> y := SSSE(SSS, 3, Transformation([1, 1]));
+SSSE(3, Transformation( [ 1, 1 ] ))
+gap> z := SSSE(SSS, 1, Transformation([2, 2]));
+SSSE(1, Transformation( [ 2, 2 ] ))
+gap> x < y;
+true
+gap> x = y;
+false
+gap> x * y;
+SSSE(1, Transformation( [ 2, 2 ] ))
+gap> z = x * y;
+true
+gap> SSS = StrongSemilatticeOfSemigroups(x);
+true
+
+# constructions: strong semilattices of semigroups: full worked example (SLOW!)
+#
+#           5     4
+#          / \   /
+#         /   \ /
+#        2     3
+#         \   /
+#          \ /
+#           1
+#
+gap> S1 := Semigroup(Transformation([1, 1, 1]),
+>                    Transformation([1, 2, 3]),
+>                    Transformation([1, 3, 2]));;
+gap> S2 := MagmaWithZeroAdjoined(SymmetricGroup(3));;
+gap> S3 := FullTransformationMonoid(4);;
+gap> S4 := RightZeroSemigroup(4);;
+gap> S5 := FullTransformationMonoid(3);;
+gap> map53f := function(trans)
+>      local temp, out;
+>      # A clever way of embedding T3 in T4, fixing the point 1 rather than 4.
+>      temp := ShallowCopy(ListTransformation(trans)) + 1;
+>      out  := [1];
+>      Append(out, temp);
+>      return Transformation(out);
+>    end;;
+gap> map53 := MappingByFunction(S5, S3, map53f);;
+gap> cong31  := SemigroupCongruence(S3, [[Transformation([1, 2, 4, 3]),
+>                                         Transformation([1, 3, 2, 4])]]);;
+gap> # this congruence separates T_4 into three sets:
+gap> # A_4;
+gap> # S_4 \ A_4;
+gap> # all transformations with size of image < 4.
+gap> cong311 := CongruenceClassOfElement(cong31,
+>                                        Transformation([1, 2, 3, 1]));;
+gap> cong312 := CongruenceClassOfElement(cong31,
+>                                        IdentityTransformation);;
+gap> cong313 := CongruenceClassOfElement(cong31,
+>                                        Transformation([2, 3, 4, 1]));;
+gap> map31f := function(trans)
+>      if trans in cong311 then
+>        return Transformation([1, 1, 1]);
+>      elif trans in cong312 then
+>        return Transformation([1, 2, 3]);
+>      elif trans in cong313 then
+>        return Transformation([1, 3, 2]);
+>      else
+>        return fail;
+>      fi;
+>    end;;
+gap> map31 := MappingByFunction(S3, S1, map31f);;
+gap> map52f := function(trans)
+>      if Length(ImageSetOfTransformation(trans, 3)) < 3 then
+>        return MultiplicativeZero(S2);
+>      else
+>        return PermutationOfImage(trans) ^ UnderlyingInjectionZeroMagma(S2);
+>      fi;
+>    end;;
+gap> map52 := MappingByFunction(S5, S2, map52f);;
+gap> map21f := function(magelem)
+>      local perm;
+>      perm := magelem ^ InverseGeneralMapping(UnderlyingInjectionZeroMagma(S2));
+>      if perm = fail then
+>        return Transformation([1, 1, 1]);
+>      elif perm in AlternatingGroup(3) then
+>        return Transformation([1, 2, 3]);
+>      else
+>        return Transformation([1, 3, 2]);
+>      fi;
+>    end;;
+gap> map21 := MappingByFunction(S2, S1, map21f);;
+gap> map43 := IdentityMapping(S3);;
+gap> D := Digraph([[2, 3], [5], [4, 5], [], []]);;
+gap> L := [S1, S2, S3, S4, S5];;
+gap> H := [[map21, map31], [map52], [map43, map53], [], []];;
+gap> sl := StrongSemilatticeOfSemigroups(D, L, H);
+<strong semilattice of 5 semigroups>
+gap> IsStrongSemilatticeOfSemigroups(sl);
+true
+gap> Size(sl);
+297
+gap> Length(GreensDClasses(sl));
+12
+gap> x := SSSE(sl, 2, (1, 2) ^ UnderlyingInjectionZeroMagma(S2));;
+gap> y := SSSE(sl, 3, Transformation([1, 4, 3, 2]));;
+gap> z := SSSE(sl, 1, IdentityTransformation);;
+gap> x * y = z;
+true
+gap> x := SSSE(sl, 4, Transformation([4, 4, 4, 4]));;
+gap> y := SSSE(sl, 5, Transformation([3, 3, 2]));;
+gap> z := SSSE(sl, 3, Transformation([3, 3, 3, 3]));;
+gap> x * y = z;
+true
+gap> MultiplicativeZero(sl);
+SSSE(1, Transformation( [ 1, 1, 1 ] ))
+gap> MultiplicativeNeutralElement(sl);
+fail
+
 #
 gap> Unbind(S);
 


### PR DESCRIPTION
This PR changes the ViewString method for SSS objects to avoid using `StringFormatted` which Travis CI was complaining about.