### PR TITLE
Strong Semilattice Documentation Update

### DIFF
--- a/doc/z-chap09.xml
+++ b/doc/z-chap09.xml
@@ -50,11 +50,9 @@
     The product of two elements <M>x \in S_a, y \in S_b</M> is defined to lie
     in the semigroup <M>S_c</M>, corresponding to the meet <M>c</M> of
     <M>a, b \in Y</M>. The exact element of <M>S_c</M> equal to the product
-    is obtained using the homomorphisms of the SSS:
+    is obtained using the homomorphisms of the SSS: <M>xy = (x f_{ac})
+    (y f_{bc})</M>.
     <P/>
-
-    <!-- TODO formatting -->
-    <M>xy = (x f_{ac})(y f_{bc}).</M>
 
     <#Include Label = "StrongSemilatticeOfSemigroups">
     <#Include Label = "SSSE">

--- a/doc/z-chap09.xml
+++ b/doc/z-chap09.xml
@@ -52,7 +52,6 @@
     <M>a, b \in Y</M>. The exact element of <M>S_c</M> equal to the product
     is obtained using the homomorphisms of the SSS: <M>xy = (x f_{ac})
     (y f_{bc})</M>.
-    <P/>
 
     <#Include Label = "StrongSemilatticeOfSemigroups">
     <#Include Label = "SSSE">


### PR DESCRIPTION
Minor update for the PR which removes a failed attempt at making a display mode equation. The equation wasn't that important so now it's just inline in the rest of the paragraph instead.